### PR TITLE
package.json and NPM

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,10 @@
 
     $ component install yields/css-ease
 
+  or via [npm](https://www.npmjs.com):
+
+    $ npm install css-ease
+
 ## Example
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "css-ease",
+  "homepage": "https://github.com/yields/css-ease",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/yields/css-ease.git"
+  },
+  "description": "css easing functions.",
+  "version": "0.0.1",
+  "keywords": ["easing"],
+  "dependencies": {},
+  "devDependencies": {},
+  "license": "MIT",
+  "main": "index.js"
+}


### PR DESCRIPTION
NPM compatibility for css-ease, the last missing part in getting [Move.js](https://github.com/visionmedia/move.js) to NPM. All other Move.js dependencies can be found from NPM already.

Only think required from you, **yields**, is to run `npm publish` after the merge. After that css-ease can be seen at https://www.npmjs.com/package/css-ease and installable by `npm install css-ease`.

If you have any further questions I'm glad to help.
